### PR TITLE
Added tekton files for pipelines and templates

### DIFF
--- a/kubernetes/tekton/cloudlog-build-pipeline.yml
+++ b/kubernetes/tekton/cloudlog-build-pipeline.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cloudlog-build-pipeline
+spec:
+  resources:
+    - name: source
+      type: git
+  params:
+    - name: shortSha
+  tasks:
+    - name: cloudlog-build-binary
+      taskRef:
+        name: cloudlog-build
+      params:
+        - name: shortSha
+          value: $(params.shortSha)
+      resources:          
+        inputs:
+          - name: source
+            resource: source

--- a/kubernetes/tekton/cloudlog-build-pipelinerun.yml
+++ b/kubernetes/tekton/cloudlog-build-pipelinerun.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: cloudlog-build-pipeline-
+spec:
+  pipelineRef:
+    name: cloudlog-build-pipeline
+  params:
+    - name: shortSha
+      value: master
+  resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+          - name: revision
+            value: master
+          - name: url
+            value: https://github.com/zcash-hackworks/cloudlog.git

--- a/kubernetes/tekton/cloudlog-build-task.yml
+++ b/kubernetes/tekton/cloudlog-build-task.yml
@@ -1,0 +1,39 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: cloudlog-build
+spec:
+  volumes:
+    - name: k8s-prod-tekton-account
+      secret:
+        secretName: k8s-prod-tekton-account
+  params:
+    - name: shortSha
+  resources:
+    inputs:
+      - name: source
+        type: git
+  steps:
+    - name: build-binary
+      image: golang
+      script: |
+        env | sort
+        pwd
+        ls -l
+        cd /workspace/source
+        ls -l
+        make build
+    - name: upload-binary
+      image: google/cloud-sdk
+      env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/k8s-prod-tekton-account/k8s-prod-tekton-account-key.json
+      volumeMounts:
+        - name: k8s-prod-tekton-account
+          mountPath: /var/secrets/k8s-prod-tekton-account
+      script: |
+        #!/usr/bin/env bash
+        pwd
+        gcloud auth activate-service-account --key-file=/var/secrets/k8s-prod-tekton-account/k8s-prod-tekton-account-key.json
+        gsutil cp /workspace/source/cloudlog gs://k8s-prod-tekton-20200319/cloudlog-$(inputs.params.shortSha)

--- a/kubernetes/tekton/cloudlog-build-taskrun.yml
+++ b/kubernetes/tekton/cloudlog-build-taskrun.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  generateName: cloudlog-build-
+spec:
+  serviceAccountName: ecc-tekton
+  taskRef:
+    name: cloudlog-build
+  inputs:
+    resources:
+      - name: source
+        resourceSpec:
+          type: git
+          params:
+            - name: revision
+              value: master
+            - name: url
+              value: https://github.com/zcash-hackworks/cloudlog.git
+    params:
+      - name: shortSha
+        value: HEAD

--- a/kubernetes/tekton/cloudlog-pr-pipeline-template.yml
+++ b/kubernetes/tekton/cloudlog-pr-pipeline-template.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: cloudlog-pr-pipeline-template
+spec:
+  params:
+    - name: gitHubProject
+      description: Github project name
+    - name: gitRepositoryURL
+      description: Git repo url
+    - name: gitCommit
+      description: Git commit to build from
+      default: master
+    - name: short_sha
+      description: Short sha from git commit used to identify binaries
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: cloudlog-pr-pipeline-
+      spec:
+        serviceAccountName: ecc-tekton
+        pipelineRef:
+          name: cloudlog-pr-pipeline
+        resources:
+          - name: source
+            resourceSpec:
+              type: git
+              params:
+                - name: revision
+                  value: $(params.gitCommit)
+                - name: url
+                  value: $(params.gitRepositoryURL)
+        params:
+          - name: shortSha
+            value: $(params.short_sha)
+          - name: gitRepositoryURL
+            value: $(params.gitRepositoryURL)
+          - name: gitCommit
+            value: $(params.gitCommit)
+          - name: gitHubProject
+            value: $(params.gitHubProject)              

--- a/kubernetes/tekton/cloudlog-pr-pipeline.yml
+++ b/kubernetes/tekton/cloudlog-pr-pipeline.yml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cloudlog-pr-pipeline
+spec:
+  resources:
+    - name: source
+      type: git
+  params:
+    - name: shortSha
+    - name: gitHubProject
+    - name: gitCommit
+  tasks:
+    - name: set-status-pending
+      taskRef:
+        name: github-set-status
+      params:
+        - name: REPO_FULL_NAME
+          value: $(params.gitHubProject)
+        - name: SHA
+          value: $(params.gitCommit)
+        - name: TARGET_URL
+          value: http://google.com
+        - name: DESCRIPTION
+          value: Attempting to build a binary
+        - name: CONTEXT
+          value: cloudlog-build-binary/check
+        - name: STATE
+          value: pending
+    - name: cloudlog-build-binary
+      runAfter:
+        - set-status-pending
+      taskRef:
+        name: cloudlog-build
+      params:
+        - name: shortSha
+          value: $(params.shortSha)
+      resources:
+        inputs:
+          - name: source
+            resource: source
+    - name: set-status-success
+      runAfter:
+        - cloudlog-build-binary
+      taskRef:
+        name: github-set-status
+      params:
+        - name: REPO_FULL_NAME
+          value: $(params.gitHubProject)  
+        - name: SHA
+          value: $(params.gitCommit)  
+        - name: TARGET_URL
+          value: http://google.com
+        - name: DESCRIPTION
+          value: Sucessfully built a binary
+        - name: CONTEXT
+          value: cloudlog-build-binary/check
+        - name: STATE
+          value: success

--- a/kubernetes/tekton/cloudlog-pr-template.yml
+++ b/kubernetes/tekton/cloudlog-pr-template.yml
@@ -1,0 +1,37 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: cloudlog-pr-template
+spec:
+  params:
+    - name: gitRepositoryURL
+      description: Git repo url
+    - name: gitCommit
+      description: Git commit to build from
+      default: master
+    - name: short_sha
+      description: Short sha from git commit used to identify binaries
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: TaskRun
+      metadata:
+        generateName: cloudlog-build-
+      spec:
+        serviceAccountName: ecc-tekton
+        taskRef:
+          name: cloudlog-build
+        resources:
+          inputs:
+            - name: source
+              resourceSpec:
+                type: git
+                params:
+                  - name: revision
+                    value: $(params.gitCommit)
+                  - name: url
+                    value: $(params.gitRepositoryURL)
+        params:
+          - name: shortSha
+            value: $(params.short_sha)
+  

--- a/kubernetes/tekton/cloudlog-pr-triggerbinding.yml
+++ b/kubernetes/tekton/cloudlog-pr-triggerbinding.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: cloudlog-pr-binding
+spec:
+  params:
+  - name: dockerImageName
+    value: electriccoinco/cloudlog
+  - name: gitCommit
+    value: $(body.pull_request.head.sha)
+  - name: short_sha
+    value: $(body.short_sha)
+  - name: gitRepositoryURL
+    value: $(body.repository.clone_url)
+  - name: gitHubProject
+    value: $(body.repository.full_name)

--- a/kubernetes/tekton/docker-build-taskrun.yml
+++ b/kubernetes/tekton/docker-build-taskrun.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: cloudlog-docker-build-
+spec:
+  serviceAccountName: zcashsysadmin-service
+  taskRef:
+    name: build-docker-image-from-git-source
+  inputs:
+    resources:
+      - name: docker-source
+        resourceSpec:
+          type: git
+          params:
+            - name: revision
+              value: master
+            - name: url
+              value: https://github.com/zcash-hackworks/cloudlog.git
+    params:
+      - name: pathToDockerFile
+        value: /workspace/docker-source/Dockerfile
+      - name: pathToContext
+        value: /workspace/docker-source/
+  outputs:
+    resources:
+      - name: builtImage
+        resourceSpec:
+          type: image
+          params:
+            - name: url
+              value: electriccoinco/cloudlog
+      - name: notification
+        resourceRef:
+          name: event-to-cloudlog


### PR DESCRIPTION
Tekton files to test that PR's opened to this repo build successfully.

`kubernetes/tekton/cloudlog-build-task.yml` defines a task to build a binary

`kubernetes/tekton/cloudlog-build-taskrun.yml` provides an example of how to run the task manually.

`kubernetes/tekton/cloudlog-pr-triggerbinding.yml` cannot be run independently. It will be used by an EventListener to map events to triggers.

`kubernetes/tekton/cloudlog-pr-pipeline-template.yml` is the pipeline the triggerbinding will generate.

`kubernetes/tekton/cloudlog-pr-pipeline.yml` is the pipeline that the pipeline-template refers to.
